### PR TITLE
Add Nix devshell for development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "Development environment for Python FastAPI deployment project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Python and package management
+            python311
+            uv
+
+            # Build and task runner
+            just
+
+            # Container tools
+            docker
+            docker-compose
+
+            # Network and deployment tools
+            curl
+            openssh
+            netcat-gnu
+
+            # JSON processing
+            jq
+
+            # System utilities
+            envsubst
+            nettools
+
+            # Development tools
+            git
+            gnumake
+          ];
+
+          shellHook = ''
+            echo "🚀 Development environment ready!"
+            echo "Available tools:"
+            echo "  • uv (Python package manager)"
+            echo "  • just (command runner)"
+            echo "  • docker & docker-compose (containers)"
+            echo "  • curl, ssh, jq (deployment tools)"
+            echo ""
+            echo "Run 'just' to see available commands"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
• Added `flake.nix` with comprehensive development environment
• Includes all tools needed for Python FastAPI development and deployment
• Provides Python 3.11, uv, just, Docker, curl, jq, and other essential tools

## Test plan
- [ ] Run `nix develop` to enter development environment
- [ ] Verify all tools are available (uv, just, docker, curl, etc.)
- [ ] Test development workflow with `just install` and `just test`

🤖 Generated with [Claude Code](https://claude.ai/code)